### PR TITLE
Implement dummy runner and basic instance runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,170 @@ DELETE /v1/minion/{account}/jobs/{id}
 
 Authentication is accomplished via a pre-shared key.  This is done via the `X-Auth-Token` header.
 
+## Job Types
+
+### dummy
+
+A dummy runner job just attempts to execute a template with the given account name and return that string.
+
+#### example dummy job
+
+```json
+{
+    "description": "Do some dumb thing to my server",
+    "details": {
+        "runner": "dummyRunner",
+    },
+    "group": "space-xy",
+    "id": "6bcfa79f-615e-470d-97c1-687f3357497d",
+    "modified_at": "2020-02-27T16:22:09Z",
+    "modified_by": "someone",
+    "name": "dummy-spin1234567",
+    "schedule_expression": "* * * ? *",
+    "enabled": true
+}
+```
+
+### instance
+
+An instance runner job executes an action on an instance.  Currently supported actions are `stop`, `start` and `reboot`
+
+#### example instance job
+
+```json
+{
+    "description": "Start my server",
+    "details": {
+        "instance_action": "start",
+        "instance_id": "i-aaaabbbb11112222",
+        "runner": "instanceRunner"
+    },
+    "group": "space-xy",
+    "id": "7cf7433f-f6c2-496e-8fe9-ed4776d130c1",
+    "modified_at": "2020-02-28T18:14:26Z",
+    "modified_by": "someone",
+    "name": "start-spinaaaabbbb11112222",
+    "schedule_expression": "* * * ? *",
+    "enabled": true
+}
+```
+
+## Create a Job
+
+POST `/v1/minion/{account}/jobs`
+
+### Request
+
+```json
+{
+    "description": "Do some dumb thing to my server",
+    "details": {
+        "runner": "dummyRunner",
+    },
+    "group": "space-xy",
+    "modified_by": "someone",
+    "name": "dummy-spin1234567",
+    "schedule_expression": "* * * ? *",
+    "enabled": true
+}
+```
+
+### Response
+
+```json
+{
+    "description": "Do some dumb thing to my server",
+    "details": {
+        "runner": "dummyRunner",
+    },
+    "group": "space-xy",
+    "id": "6bcfa79f-615e-470d-97c1-687f3357497d",
+    "modified_at": "2020-02-27T16:22:09Z",
+    "modified_by": "someone",
+    "name": "dummy-spin1234567",
+    "schedule_expression": "* * * ? *",
+    "enabled": true
+}
+```
+
+## Update a Job
+
+PUT `/v1/minion/{account}/jobs/{id}`
+
+### Request
+
+```json
+{
+    "description": "Do some dumb thing to my server",
+    "details": {
+        "runner": "dummyRunner",
+    },
+    "group": "space-xy",
+    "id": "6bcfa79f-615e-470d-97c1-687f3357497d",
+    "modified_by": "someone",
+    "name": "dummy-spin1234567",
+    "schedule_expression": "* * * ? *",
+    "enabled": false
+}
+```
+
+### Response
+
+```json
+{
+    "description": "Do some dumb thing to my server",
+    "details": {
+        "runner": "dummyRunner",
+    },
+    "group": "space-xy",
+    "id": "6bcfa79f-615e-470d-97c1-687f3357497d",
+    "modified_at": "2020-02-28T16:22:09Z",
+    "modified_by": "someone",
+    "name": "dummy-spin1234567",
+    "schedule_expression": "* * * ? *",
+    "enabled": false
+}
+```
+
+## List Jobs
+
+GET `/v1/minion/{account}/jobs`
+
+### Response
+
+```json
+[
+    "11e7b876-7a10-4c3e-93a7-e77eb3c68b58",
+    "6bcfa79f-615e-470d-97c1-687f3357497d",
+    "747f437a-a4af-48b2-a021-888bb8943a9b",
+    "7cf7433f-f6c2-496e-8fe9-ed4776d130c1"
+]
+```
+
+## Get a Job
+
+GET `/v1/minion/{account}/jobs/{id}`
+
+```json
+{
+    "description": "Do some dumb thing to my server",
+    "details": {
+        "runner": "dummyRunner",
+    },
+    "group": "space-xy",
+    "id": "6bcfa79f-615e-470d-97c1-687f3357497d",
+    "modified_at": "2020-02-28T16:22:09Z",
+    "modified_by": "someone",
+    "name": "dummy-spin1234567",
+    "schedule_expression": "* * * ? *",
+    "enabled": true
+}
+```
+
+## Delete a Job
+
+DELETE `/v1/minion/{account}/jobs/{id}`
+
 ## Author
 
 E Camden Fisher <camden.fisher@yale.edu>

--- a/api/routes.go
+++ b/api/routes.go
@@ -17,4 +17,7 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/jobs/{id}", s.JobsShowHandler).Methods(http.MethodGet)
 	api.HandleFunc("/{account}/jobs/{id}", s.JobsUpdateHandler).Methods(http.MethodPut)
 	api.HandleFunc("/{account}/jobs/{id}", s.JobsDeleteHandler).Methods(http.MethodDelete)
+
+	// TODO: remove this route one the jobs are running on a schedule
+	api.HandleFunc("/{account}/jobs/{id}", s.JobsRunHandler).Methods(http.MethodPatch)
 }

--- a/common/config.go
+++ b/common/config.go
@@ -12,8 +12,9 @@ import (
 type Config struct {
 	Accounts       map[string]Account
 	JobsRepository JobsRepository
-	LockProvider   LockProvider
+	JobRunners     map[string]JobRunner
 	ListenAddress  string
+	LockProvider   LockProvider
 	Token          string
 	LogLevel       string
 	Version        Version
@@ -21,7 +22,14 @@ type Config struct {
 }
 
 // Account is the configuration for an individual account
-type Account struct{}
+type Account struct {
+	Runners []string
+}
+
+type JobRunner struct {
+	Type   string
+	Config map[string]interface{}
+}
 
 type JobsRepository struct {
 	Type          string

--- a/common/config_test.go
+++ b/common/config_test.go
@@ -7,17 +7,97 @@ import (
 )
 
 var testConfig = []byte(
-	`{
+	`{ 
+		"accounts": {
+		  "myaccount": {
+			"runners": ["dummyRunner", "instanceRunner"]
+		  }
+		},
+		"jobsRepository": {
+			"type": "s3",
+			"refreshPeriod": "60m",
+			"config": {
+				"region": "us-east-1",
+				"akid": "keykeykeykeykeykeykey",
+				"secret": "secretsecretsecretsecretsecret",
+				"bucket": "myjobsrepository",
+				"prefix": "jobs"
+			}
+		},
+		"jobRunners": {
+			"dummyRunner": {
+				"type": "dummy",
+				"config": {
+					"template": "Hello, {{.Account}}!"
+				}
+			},
+			"instanceRunner": {
+				"type": "instance",
+				"config": {
+					"endpoint": "http://127.0.0.1:8080/v1/ec2/power",
+					"token": "yyyyyyyy"
+				}
+			}
+		},
+		"lockProvider": {
+			"type": "redis",
+			"ttl": "5m",
+			"config": {
+				"database": 2,
+				"host": "127.0.0.1",
+				"port": 6379
+			}
+		},
 		"listenAddress": ":8000",
 		"token": "SEKRET",
 		"logLevel": "info",
 		"org": "test"
-	}`)
+	  }`)
 
 var brokenConfig = []byte(`{ "foobar": { "baz": "biz" }`)
 
 func TestReadConfig(t *testing.T) {
 	expectedConfig := Config{
+		Accounts: map[string]Account{
+			"myaccount": Account{
+				Runners: []string{"dummyRunner", "instanceRunner"},
+			},
+		},
+		JobsRepository: JobsRepository{
+			Type:          "s3",
+			RefreshPeriod: "60m",
+			Config: map[string]interface{}{
+				"akid":   "keykeykeykeykeykeykey",
+				"secret": "secretsecretsecretsecretsecret",
+				"bucket": "myjobsrepository",
+				"prefix": "jobs",
+				"region": "us-east-1",
+			},
+		},
+		JobRunners: map[string]JobRunner{
+			"dummyRunner": JobRunner{
+				Type: "dummy",
+				Config: map[string]interface{}{
+					"template": "Hello, {{.Account}}!",
+				},
+			},
+			"instanceRunner": JobRunner{
+				Type: "instance",
+				Config: map[string]interface{}{
+					"endpoint": "http://127.0.0.1:8080/v1/ec2/power",
+					"token":    "yyyyyyyy",
+				},
+			},
+		},
+		LockProvider: LockProvider{
+			Type: "redis",
+			TTL:  "5m",
+			Config: map[string]interface{}{
+				"database": float64(2),
+				"host":     "127.0.0.1",
+				"port":     float64(6379),
+			},
+		},
 		ListenAddress: ":8000",
 		Token:         "SEKRET",
 		LogLevel:      "info",

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,6 +1,23 @@
 { 
   "accounts": {
-    "myaccount": {}
+    "myaccount": {
+      "runners": ["dummyRunner", "instanceRunner"]
+    }
+  },
+  "jobRunners": {
+    "dummyRunner": {
+      "type": "dummy",
+      "config": {
+        "template": "Hello, {{.Account}}!"
+      }
+    },
+    "instanceRunner": {
+      "type": "instance",
+      "config": {
+        "endpointTemplate": "http://127.0.0.1:8080/v1/ec2/{{.Account}}/instances/{{.InstanceID}}/power",
+        "token": "yyyyyyyy"
+      }
+    }
   },
   "jobsRepository": {
     "type": "s3",
@@ -9,7 +26,7 @@
       "region": "us-east-1",
       "akid": "keykeykeykeykeykeykey",
       "secret": "secretsecretsecretsecretsecret",
-      "bucket": "my-jobsrepository",
+      "bucket": "myjobsrepository",
       "prefix": "jobs"
     }
   },

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/YaleSpinup/minion
 
-go 1.13
+go 1.14
 
 require (
-	github.com/aws/aws-sdk-go v1.29.11
+	github.com/aws/aws-sdk-go v1.29.13
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -54,6 +55,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -79,11 +81,13 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -94,6 +98,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
@@ -102,4 +107,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,9 @@
-github.com/YaleSpinup/ds-api v0.0.0-20200219115917-3a883e404247 h1:KQSrGNfeQONgM7c5wnCsVZ/I0Jq+coTwgFFIAReTZnM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/aws/aws-sdk-go v1.29.11 h1:f1QJRPu30p0i1lzKhkSSaZFudFGCra2HKgdE442nN6c=
-github.com/aws/aws-sdk-go v1.29.11/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
+github.com/aws/aws-sdk-go v1.29.13 h1:Y77U33nj5ic5hVxE6Th4LhZaw2rSwl3mXIm9OdmIs+k=
+github.com/aws/aws-sdk-go v1.29.13/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -12,7 +11,6 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -56,7 +54,6 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -82,13 +79,11 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -99,7 +94,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
@@ -108,5 +102,4 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/jobs/dummyrunner.go
+++ b/jobs/dummyrunner.go
@@ -1,0 +1,59 @@
+package jobs
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"text/template"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type DummyRunner struct {
+	Template string
+}
+
+// NewDummyRunner creates a new dummy runner that doesn't do anything, but requires a
+// template and returns that executed template when called
+func NewDummyRunner(config map[string]interface{}) (*DummyRunner, error) {
+	log.Debug("creating new dummy job runner")
+
+	var template string
+	if v, ok := config["template"].(string); ok {
+		template = v
+	}
+
+	if template == "" {
+		return nil, errors.New("template cannot be empty")
+	}
+
+	return &DummyRunner{Template: template}, nil
+}
+
+// Run executes the DummyRunner, ignoring the parameters
+func (r *DummyRunner) Run(ctx context.Context, account string, parameters interface{}) (string, error) {
+	if account == "" {
+		return "", errors.New("account is required")
+	}
+
+	log.Infof("running dummy runner %+v in account %s,  with parameters %+v", r, account, parameters)
+
+	input := struct {
+		Account string
+	}{account}
+
+	tmpl, err := template.New("dummy").Parse(r.Template)
+	if err != nil {
+		return "", err
+	}
+
+	var out bytes.Buffer
+	if err := tmpl.Execute(&out, &input); err != nil {
+		return "", err
+	}
+
+	msg := out.String()
+	log.Debugf("output of template: %s", msg)
+
+	return msg, nil
+}

--- a/jobs/dummyrunner.go
+++ b/jobs/dummyrunner.go
@@ -44,12 +44,12 @@ func (r *DummyRunner) Run(ctx context.Context, account string, parameters interf
 
 	tmpl, err := template.New("dummy").Parse(r.Template)
 	if err != nil {
-		return "", err
+		return "", NewRunnerError(ErrPreExecFailure, "template parsing failed", err)
 	}
 
 	var out bytes.Buffer
 	if err := tmpl.Execute(&out, &input); err != nil {
-		return "", err
+		return "", NewRunnerError(ErrPreExecFailure, "template parsing failed", err)
 	}
 
 	msg := out.String()

--- a/jobs/dummyrunner_test.go
+++ b/jobs/dummyrunner_test.go
@@ -1,0 +1,73 @@
+package jobs
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestNewDummyRunner(t *testing.T) {
+	_, err := NewDummyRunner(map[string]interface{}{})
+	if err == nil {
+		t.Error("expected error from empty configuration, got nil")
+	}
+
+	config := map[string]interface{}{
+		"foo": "bar",
+	}
+	_, err = NewDummyRunner(config)
+	if err == nil {
+		t.Error("expected error from missing template, got nil")
+	}
+
+	config["template"] = []string{"biz", "boz", "baz"}
+	_, err = NewDummyRunner(config)
+	if err == nil {
+		t.Error("expected error from template of wrong type, got nil")
+	}
+
+	config["template"] = "my awesome template"
+	out, err := NewDummyRunner(config)
+	if err != nil {
+		t.Errorf("expected nil error from set template, got %s", err)
+	}
+
+	if d := reflect.TypeOf(out).String(); d != "*jobs.DummyRunner" {
+		t.Errorf("expected type to be '*jobs.DummyRunner', got '%s'", d)
+	}
+}
+
+func TestDummyRunnerRun(t *testing.T) {
+	dummyRunner, err := NewDummyRunner(map[string]interface{}{
+		"template": "Hi, {{.Account}}!",
+	})
+	if err != nil {
+		t.Errorf("expected nil error from new dummyrunner, got %s", err)
+	}
+
+	_, err = dummyRunner.Run(context.TODO(), "", "foo")
+	if err == nil {
+		t.Error("expected error for empty account, got nil")
+	}
+
+	out, err := dummyRunner.Run(context.TODO(), "myaccount", "foo")
+	if err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
+
+	if out != "Hi, myaccount!" {
+		t.Errorf("expected 'Hi, myaccount', got '%s'", out)
+	}
+
+	badDummyRunner, err := NewDummyRunner(map[string]interface{}{
+		"template": "Hi, {{.Blarg}}!",
+	})
+	if err != nil {
+		t.Errorf("expected nil error from new dummyrunner, got %s", err)
+	}
+
+	_, err = badDummyRunner.Run(context.TODO(), "myaccount", "foo")
+	if err == nil {
+		t.Error("expected error for bad template, got nil")
+	}
+}

--- a/jobs/instancerunner.go
+++ b/jobs/instancerunner.go
@@ -1,0 +1,156 @@
+package jobs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"text/template"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type InstanceRunner struct {
+	Endpoint         string
+	EndpointTemplate string
+	Token            string
+}
+
+// NewInstanceRunner creates and configures a new instance runner.  An endpoint or endpoint template is required
+// the endpoint and endpoint template are not currently validated but this can/should be done in the future.  If a
+// a token is passed, it will be configured but is not required.
+func NewInstanceRunner(config map[string]interface{}) (*InstanceRunner, error) {
+	log.Debug("creating new dummy job runner")
+
+	var endpoint string
+	if v, ok := config["endpoint"].(string); ok {
+		endpoint = v
+	}
+
+	var endpointTemplate string
+	if v, ok := config["endpointTemplate"].(string); ok {
+		endpointTemplate = v
+	}
+
+	if endpoint == "" && endpointTemplate == "" {
+		return nil, errors.New("endpoint or endpoint_template is required")
+	} else if endpoint != "" && endpointTemplate != "" {
+		log.Warn("both endpoint and endpoint_template are set, only endpoint will be used")
+	}
+
+	var token string
+	if v, ok := config["token"].(string); ok {
+		token = v
+	}
+
+	return &InstanceRunner{
+		Endpoint:         endpoint,
+		EndpointTemplate: endpointTemplate,
+		Token:            token,
+	}, nil
+}
+
+// Run executes the InstanceRunner.  The instance_id and instance_action are required.  Allowable actions
+// are 'start', 'stop' and 'reboot'.  If an endpoint is configured on the runner, it will be used, otherwise
+// we assume there is an endpointTemplate and try to execute it.  Instance actions are currently only
+// executed with the PUT method and a body containing {"state": "action"}.
+func (r *InstanceRunner) Run(ctx context.Context, account string, parameters interface{}) (string, error) {
+	if account == "" {
+		return "", errors.New("account is required")
+	}
+
+	log.Infof("running instance runner %+v in account %s,  with parameters %+v", r, account, parameters)
+
+	instanceID, err := stringMapParameter("instance_id", parameters)
+	if err != nil {
+		return "", err
+	}
+
+	action, err := stringMapParameter("instance_action", parameters)
+	if err != nil {
+		return "", err
+	}
+
+	endpoint := r.Endpoint
+	if endpoint == "" {
+		log.Debugf("endpoint is empty, attempting to use endpoint template '%s'", r.EndpointTemplate)
+
+		input := struct {
+			Account    string
+			InstanceID string
+		}{account, instanceID}
+
+		tmpl, err := template.New("endpoint").Parse(r.EndpointTemplate)
+		if err != nil {
+			return "", err
+		}
+
+		var out bytes.Buffer
+		if err := tmpl.Execute(&out, &input); err != nil {
+			return "", err
+		}
+
+		endpoint = out.String()
+		log.Debugf("parsed endpoint template: %s", endpoint)
+
+	}
+
+	switch action {
+	case "reboot", "stop", "start":
+		j, err := json.Marshal(map[string]string{"state": action})
+		if err != nil {
+			return "", err
+		}
+
+		client := &http.Client{
+			Timeout: time.Second * 30,
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(j))
+		if err != nil {
+			return "", err
+		}
+
+		if r.Token != "" {
+			req.Header.Set("Auth-Token", r.Token)
+		}
+
+		res, err := client.Do(req)
+		if err != nil {
+			return "", err
+		}
+
+		defer res.Body.Close()
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return "", err
+		}
+
+		log.Debugf("got response %s(%d) for endpoint %s: %s", res.Status, res.StatusCode, endpoint, body)
+
+		if res.StatusCode >= 300 {
+			return "", errors.New("unexpected response from instanceRunner api: " + res.Status)
+		}
+
+		return string(body), nil
+	default:
+		return "", fmt.Errorf("unexpected action '%s' for instance %s", action, instanceID)
+	}
+}
+
+// stringMapParameter is the most common case for parameters - string value of a map[string]string
+func stringMapParameter(key string, parameters interface{}) (string, error) {
+	log.Debugf("trying to get parameter value for key %s from parameters '%+v'", key, parameters)
+	if p, ok := parameters.(map[string]string); !ok {
+		return "", errors.New("parameter list is not a map[string]string")
+	} else {
+		if i, ok := p[key]; !ok {
+			return "", errors.New("key " + key + " was not found in the map[string]interface{} parameter")
+		} else {
+			return i, nil
+		}
+	}
+}

--- a/jobs/instancerunner.go
+++ b/jobs/instancerunner.go
@@ -136,7 +136,7 @@ func (r *InstanceRunner) Run(ctx context.Context, account string, parameters int
 		log.Debugf("got response %s(%d) for endpoint %s: %s", res.Status, res.StatusCode, endpoint, body)
 
 		if res.StatusCode >= 300 {
-			return "", NewRunnerError(ErrExecFailure, "unexpected http respons", errors.New("unexpected response from instanceRunner api: "+res.Status))
+			return "", NewRunnerError(ErrExecFailure, "unexpected http response", errors.New("unexpected response from instanceRunner api: "+res.Status))
 		}
 
 		return string(body), nil

--- a/jobs/instancerunner_test.go
+++ b/jobs/instancerunner_test.go
@@ -1,0 +1,252 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestNewInstanceRunner(t *testing.T) {
+	_, err := NewInstanceRunner(map[string]interface{}{})
+	if err == nil {
+		t.Error("expected error from empty configuration, got nil")
+	}
+
+	config := map[string]interface{}{
+		"foo": "bar",
+	}
+	_, err = NewInstanceRunner(config)
+	if err == nil {
+		t.Error("expected error from missing endpoint and endpointTemplate, got nil")
+	}
+
+	config["endpointTemplate"] = []string{"biz", "boz", "baz"}
+	_, err = NewInstanceRunner(config)
+	if err == nil {
+		t.Error("expected error from endpointTemplate of wrong type, got nil")
+	}
+
+	config["endpoint"] = []string{"biz", "boz", "baz"}
+	_, err = NewInstanceRunner(config)
+	if err == nil {
+		t.Error("expected error from endpoint of wrong type, got nil")
+	}
+
+	expectedEndpointTemplate := "{{.Account}}"
+	config["endpointTemplate"] = expectedEndpointTemplate
+	_, err = NewInstanceRunner(config)
+	if err != nil {
+		t.Errorf("expected nil error from set endpointTemplate, got %s", err)
+	}
+
+	expectedEndpoint := "some endpoint"
+	config["endpoint"] = expectedEndpoint
+	_, err = NewInstanceRunner(config)
+	if err != nil {
+		t.Errorf("expected nil error from set endpoint, got %s", err)
+	}
+
+	expectedToken := "my-awesome-token"
+	config["token"] = expectedToken
+
+	out, err := NewInstanceRunner(config)
+	if err != nil {
+		t.Errorf("expected nil error from set token, got %s", err)
+	}
+
+	if d := reflect.TypeOf(out).String(); d != "*jobs.InstanceRunner" {
+		t.Errorf("expected type to be '*jobs.InstanceRunner', got '%s'", d)
+	}
+
+	if out.Endpoint != expectedEndpoint {
+		t.Errorf("expected endpoint to be '%s', got '%s'", expectedEndpoint, out.Endpoint)
+	}
+
+	if out.EndpointTemplate != expectedEndpointTemplate {
+		t.Errorf("expected endpoint token to be '%s', got '%s'", expectedEndpointTemplate, out.EndpointTemplate)
+	}
+
+	if out.Token != expectedToken {
+		t.Errorf("expected token to be '%s', got '%s'", expectedToken, out.Token)
+	}
+}
+
+func TestInstanceRunnerRun(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			fmt.Fprint(w, "unexpected method "+r.Method)
+			return
+		}
+
+		tok := r.Header.Get("Auth-Token")
+		if tok != "my-awesome-token" {
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprint(w, "bad token")
+			return
+		}
+
+		if r.URL.String() == "/" {
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprint(w, "OK")
+		} else if r.URL.String() == "/myaccount/i-123456" {
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprint(w, "KO")
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, "derp")
+		}
+	}))
+	defer ts.Close()
+
+	instanceRunner, err := NewInstanceRunner(map[string]interface{}{
+		"token":    "my-awesome-token",
+		"endpoint": ts.URL,
+	})
+	if err != nil {
+		t.Errorf("expected nil error from set token, got %s", err)
+	}
+
+	if _, err = instanceRunner.Run(context.TODO(), "", "foo"); err == nil {
+		t.Error("expected error for empty account, got nil")
+	}
+
+	if _, err = instanceRunner.Run(context.TODO(), "", map[string]string{}); err == nil {
+		t.Error("expected error for missing instance_id, got nil")
+	}
+
+	if _, err = instanceRunner.Run(context.TODO(), "", map[string]interface{}{
+		"instance_id": []string{"foo", "bar"},
+	}); err == nil {
+		t.Error("expected error for wrong instance_id type, got nil")
+	}
+
+	if _, err = instanceRunner.Run(context.TODO(), "", map[string]interface{}{
+		"instance_id": "i-123456",
+	}); err == nil {
+		t.Error("expected error for missing instance_action, got nil")
+	}
+
+	if _, err = instanceRunner.Run(context.TODO(), "", map[string]interface{}{
+		"instance_id":     "i-123456",
+		"instance_action": []string{"reboot", "stop", "start"},
+	}); err == nil {
+		t.Error("expected error for wrong instance_action type, got nil")
+	}
+
+	out, err := instanceRunner.Run(context.TODO(), "myaccount", map[string]string{
+		"instance_id":     "i-123456",
+		"instance_action": "stop",
+	})
+	if err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
+
+	if out != "OK" {
+		t.Errorf("expected OK, got %s", out)
+	}
+
+	_, err = instanceRunner.Run(context.TODO(), "myaccount", map[string]string{
+		"instance_id":     "i-123456",
+		"instance_action": "delete",
+	})
+	if err == nil {
+		t.Error("expected error for bad action, got nil")
+	}
+
+	instanceRunnerTmpl, err := NewInstanceRunner(map[string]interface{}{
+		"token":            "my-awesome-token",
+		"endpointTemplate": fmt.Sprintf("%s/{{.Account}}/{{.InstanceID}}", ts.URL),
+	})
+
+	out, err = instanceRunnerTmpl.Run(context.TODO(), "myaccount", map[string]string{
+		"instance_id":     "i-123456",
+		"instance_action": "stop",
+	})
+	if err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
+
+	if out != "KO" {
+		t.Errorf("expected OK, got %s", out)
+	}
+
+	instanceRunnerBadURL, err := NewInstanceRunner(map[string]interface{}{
+		"token":            "my-awesome-token",
+		"endpointTemplate": fmt.Sprintf("%s/some-bad-url", ts.URL),
+	})
+
+	out, err = instanceRunnerBadURL.Run(context.TODO(), "myaccount", map[string]string{
+		"instance_id":     "i-123456",
+		"instance_action": "stop",
+	})
+	if err == nil {
+		t.Error("expected error for bad URI, got nil")
+	}
+}
+
+func TestStringMapParameters(t *testing.T) {
+	type test struct {
+		key       string
+		parameter interface{}
+		out       string
+		err       error
+	}
+
+	tests := []test{
+		test{
+			key:       "foo",
+			parameter: map[string]string{"foo": "bar"},
+			out:       "bar",
+			err:       nil,
+		},
+		test{
+			key:       "foo",
+			parameter: map[string]string{"foo": "bar,baz,biz,boz"},
+			out:       "bar,baz,biz,boz",
+			err:       nil,
+		},
+		test{
+			key:       "foo",
+			parameter: map[string]string{"fuz": "biz"},
+			out:       "",
+			err:       errors.New("foo"),
+		},
+		test{
+			key:       "foo",
+			parameter: map[string]interface{}{"foo": true},
+			out:       "",
+			err:       errors.New("foo"),
+		},
+		test{
+			key:       "foo",
+			parameter: map[string]interface{}{"foo": []string{"bar", "biz"}},
+			out:       "",
+			err:       errors.New("foo"),
+		},
+		test{
+			key:       "foo",
+			parameter: nil,
+			out:       "",
+			err:       errors.New("foo"),
+		},
+	}
+
+	for _, tst := range tests {
+		out, err := stringMapParameter(tst.key, tst.parameter)
+		if err != nil && tst.err == nil {
+			t.Errorf("expected nil error, got %s", err)
+		} else if tst.err != nil && err == nil {
+			t.Error("expected error, got nil")
+		}
+
+		if out != tst.out {
+			t.Errorf("expected output %s, got %s", tst.out, out)
+		}
+	}
+
+}

--- a/jobs/job.go
+++ b/jobs/job.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,17 +24,10 @@ type Job struct {
 	ScheduleExpression string
 }
 
-// Runner has a Run method and runs a job
-type Runner interface {
-	Run(ctx context.Context, account string, parameters interface{}) (string, error)
-}
-
 // NewID returns a new ID for a job.  Currently this is just a UUID string
 func NewID() string {
 	id := uuid.New().String()
-
 	log.Debugf("generated random job id %s", id)
-
 	return id
 }
 
@@ -53,108 +45,113 @@ func (m *Job) UnmarshalJSON(j []byte) error {
 	log.Debug("unmarshaled metadata into rawstrings")
 
 	if desc, ok := rawStrings["description"]; ok {
-		if s, ok := desc.(string); !ok {
+		s, ok := desc.(string)
+		if !ok {
 			msg := fmt.Sprintf("description is not a string: %+v", rawStrings["description"])
 			return errors.New(msg)
-		} else {
-			m.Description = s
 		}
+		m.Description = s
 	}
 
 	if d, ok := rawStrings["details"]; ok {
 		details := make(map[string]string)
-		if i, ok := d.(map[string]interface{}); !ok {
+		i, ok := d.(map[string]interface{})
+		if !ok {
 			msg := fmt.Sprintf("details is not a map of strings: %+v", rawStrings["details"])
 			return errors.New(msg)
-		} else {
-			for k, v := range i {
-				if s, ok := v.(string); ok {
-					details[k] = s
-				} else {
-					msg := fmt.Sprintf("invalid type in details map, value of '%s' is not a string %T(%v)'", k, v, v)
-					return errors.New(msg)
-				}
+		}
+
+		for k, v := range i {
+			s, ok := v.(string)
+			if !ok {
+				msg := fmt.Sprintf("invalid type in details map, value of '%s' is not a string %T(%v)'", k, v, v)
+				return errors.New(msg)
 			}
+			details[k] = s
 		}
 
 		m.Details = details
 	}
 
 	if group, ok := rawStrings["group"]; ok {
-		if s, ok := group.(string); !ok {
+		s, ok := group.(string)
+		if !ok {
 			msg := fmt.Sprintf("group is not a string: %+v", rawStrings["group"])
 			return errors.New(msg)
-		} else {
-			m.Group = s
 		}
+		m.Group = s
 	}
 
 	if id, ok := rawStrings["id"]; ok {
-		if s, ok := id.(string); !ok {
+		s, ok := id.(string)
+		if !ok {
 			msg := fmt.Sprintf("id is not a string: %+v", rawStrings["id"])
 			return errors.New(msg)
-		} else {
-			m.ID = s
 		}
+		m.ID = s
 	}
 
 	if modifiedAt, ok := rawStrings["modified_at"]; ok {
-		if ma, ok := modifiedAt.(string); !ok {
+		ma, ok := modifiedAt.(string)
+		if !ok {
 			msg := fmt.Sprintf("modified_at is not a string: %+v", rawStrings["modified_at"])
 			return errors.New(msg)
-		} else {
-			if ma != "" {
-				t, err := time.Parse(time.RFC3339, ma)
-				if err != nil {
-					msg := fmt.Sprintf("failed to parse modified_at as time: %+v", t)
-					return errors.New(msg)
-				}
-				t = t.UTC().Truncate(time.Second)
-				m.ModifiedAt = &t
+		}
+
+		if ma != "" {
+			t, err := time.Parse(time.RFC3339, ma)
+			if err != nil {
+				msg := fmt.Sprintf("failed to parse modified_at as time: %+v", t)
+				return errors.New(msg)
 			}
+
+			t = t.UTC().Truncate(time.Second)
+			m.ModifiedAt = &t
 		}
 	}
 
 	if modifiedBy, ok := rawStrings["modified_by"]; ok {
-		if s, ok := modifiedBy.(string); !ok {
+		s, ok := modifiedBy.(string)
+		if !ok {
 			msg := fmt.Sprintf("modified_by is not a string: %+v", rawStrings["modified_by"])
 			return errors.New(msg)
-		} else {
-			m.ModifiedBy = s
 		}
+		m.ModifiedBy = s
 	}
 
 	if name, ok := rawStrings["name"]; ok {
-		if s, ok := name.(string); !ok {
+		s, ok := name.(string)
+		if !ok {
 			msg := fmt.Sprintf("name is not a string: %+v", rawStrings["name"])
 			return errors.New(msg)
-		} else {
-			m.Name = s
 		}
+		m.Name = s
 	}
 
 	if scheduleExpression, ok := rawStrings["schedule_expression"]; ok {
-		if s, ok := scheduleExpression.(string); !ok {
+		s, ok := scheduleExpression.(string)
+		if !ok {
 			msg := fmt.Sprintf("schedule_expression is not a string: %+v", rawStrings["schedule_expression"])
 			return errors.New(msg)
-		} else {
-			parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
-			_, err := parser.Parse(s)
-			if err != nil {
-				msg := fmt.Sprintf("schedule_expression is not a valid cron expression: '%s': %s", s, err)
-				return errors.New(msg)
-			}
-			m.ScheduleExpression = s
 		}
+
+		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+		_, err := parser.Parse(s)
+		if err != nil {
+			msg := fmt.Sprintf("schedule_expression is not a valid cron expression: '%s': %s", s, err)
+			return errors.New(msg)
+		}
+
+		m.ScheduleExpression = s
 	}
 
 	if enabled, ok := rawStrings["enabled"]; ok {
-		if s, ok := enabled.(bool); !ok {
+		s, ok := enabled.(bool)
+		if !ok {
 			msg := fmt.Sprintf("enabled is not a bool: %+v", rawStrings["enabled"])
 			return errors.New(msg)
-		} else {
-			m.Enabled = s
 		}
+		m.Enabled = s
 	}
 
 	return nil

--- a/jobs/job.go
+++ b/jobs/job.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,6 +23,11 @@ type Job struct {
 	Name               string
 	Group              string
 	ScheduleExpression string
+}
+
+// Runner has a Run method and runs a job
+type Runner interface {
+	Run(ctx context.Context, account string, parameters interface{}) (string, error)
 }
 
 // NewID returns a new ID for a job.  Currently this is just a UUID string

--- a/jobs/job_test.go
+++ b/jobs/job_test.go
@@ -68,8 +68,8 @@ func TestJobUnmarshalJSON(t *testing.T) {
 		t.Error("expected error for bad details, got nil")
 	}
 
-	// details empty
-	if err := out.UnmarshalJSON([]byte(`"details": {"foo": false}`)); err == nil {
+	// details value of wrong type
+	if err := out.UnmarshalJSON([]byte(`{"details":{"foo": false}}`)); err == nil {
 		t.Error("expected error for bad details, got nil")
 	}
 
@@ -101,6 +101,11 @@ func TestJobUnmarshalJSON(t *testing.T) {
 	// name type
 	if err := out.UnmarshalJSON([]byte(`{"name":false}`)); err == nil {
 		t.Error("expected error for bad name, got nil")
+	}
+
+	// schedule_expression invalid
+	if err := out.UnmarshalJSON([]byte(`{"schedule_expression":""}`)); err == nil {
+		t.Error("expected error for bad schedule_expression, got nil")
 	}
 
 	// schedule_expression type

--- a/jobs/runner.go
+++ b/jobs/runner.go
@@ -1,0 +1,49 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+)
+
+const ErrMissingDetails = "MissingDetails"
+const ErrPreExecFailure = "PreExecutionFailure"
+const ErrExecFailure = "ExecutionFailure"
+const ErrPostExecFailure = "PostExecutionFailure"
+
+// Runner has a Run method and runs a job
+type Runner interface {
+	Run(ctx context.Context, account string, parameters interface{}) (string, error)
+}
+
+type RunnerError struct {
+	Code    string
+	Message string
+	OrigErr error
+}
+
+// New constructs a RunnerError and returns it as an error
+func NewRunnerError(code, message string, err error) RunnerError {
+	return RunnerError{
+		Code:    code,
+		Message: message,
+		OrigErr: err,
+	}
+}
+
+// Error Satisfies the Error interface
+func (e RunnerError) Error() string {
+	return e.String()
+}
+
+// String returns the error as string
+func (e RunnerError) String() string {
+	if e.OrigErr != nil {
+		return fmt.Sprintf("%s: %s (%s)", e.Code, e.Message, e.OrigErr)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the contained error
+func (e RunnerError) Unwrap() error {
+	return e.OrigErr
+}

--- a/jobs/runner_test.go
+++ b/jobs/runner_test.go
@@ -1,0 +1,51 @@
+package jobs
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	out := NewRunnerError(ErrExecFailure, "boom", errors.New("fail"))
+	if e := reflect.TypeOf(out).String(); e != "jobs.RunnerError" {
+		t.Errorf("expect type to be jobs.RunnerError, got %s", e)
+	}
+}
+
+func TestError(t *testing.T) {
+	out := NewRunnerError(ErrExecFailure, "boom", errors.New("fail"))
+	if out.Error() != out.String() {
+		t.Errorf("expected '%s', got '%s'", out.String(), out)
+	}
+
+	out = NewRunnerError(ErrExecFailure, "boom", nil)
+	if out.Error() != out.String() {
+		t.Errorf("expected '%s', got '%s'", out.String(), out)
+	}
+}
+
+func TestString(t *testing.T) {
+	out := NewRunnerError(ErrExecFailure, "boom", errors.New("fail"))
+	expect := "ExecutionFailure: boom (fail)"
+	if out.String() != expect {
+		t.Errorf("expected '%s', got '%s'", expect, out)
+	}
+
+	out = NewRunnerError(ErrExecFailure, "boom", nil)
+	expect = "ExecutionFailure: boom"
+	if out.String() != expect {
+		t.Errorf("expected '%s', got '%s'", expect, out)
+	}
+}
+
+func TestUnwrap(t *testing.T) {
+	err := errors.New("Fail")
+
+	out := NewRunnerError(ErrExecFailure, "boom", err)
+	orig := out.Unwrap()
+
+	if orig != err {
+		t.Errorf("expect original error tp be %s, got %s", err, orig)
+	}
+}

--- a/jobs/s3repository.go
+++ b/jobs/s3repository.go
@@ -277,9 +277,10 @@ func (s *S3Repository) Update(ctx context.Context, account, id string, job *Job)
 	}
 
 	out, err := s.S3.PutObjectWithContext(ctx, &s3.PutObjectInput{
-		Bucket: aws.String(s.Bucket),
-		Key:    aws.String(key),
-		Body:   bytes.NewReader(j),
+		Body:        bytes.NewReader(j),
+		Bucket:      aws.String(s.Bucket),
+		ContentType: aws.String("application/json"),
+		Key:         aws.String(key),
 	})
 	if err != nil {
 		return nil, ErrCode("failed to put s3 object", err)


### PR DESCRIPTION
This mainly implements the basic `dummyRunner` and `instanceRunner` and the corresponding configuration wiring.  It solidifies the interface for a runner as well.  The endpoint for executing a job exists currently because the scheduler doesn't.  That `PATCH` endpoint will probably change or be removed once the scheduler is in place (although I could see a case where someone may want to test their job execution...).