### PR TITLE
Add the concept of a group to job management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ GET /v1/minion/version
 GET /v1/minion/metrics
 
 GET /v1/minion/{account}/jobs
-POST /v1/minion/{account}/jobs
-GET /v1/minion/{account}/jobs/{id}
-PUT /v1/minion/{account}/jobs/{id}
-DELETE /v1/minion/{account}/jobs/{id}
+GET /v1/minion/{account}/jobs/{group}
+POST /v1/minion/{account}/jobs/{group}
+GET /v1/minion/{account}/jobs/{group}/{id}
+PUT /v1/minion/{account}/jobs/{group}/{id}
+DELETE /v1/minion/{account}/jobs/{group}
+DELETE /v1/minion/{account}/jobs/{group}/{id}
+
+PATCH /v1/minion/{account}/jobs/{group}/{id}
 ```
 
 ## Usage
@@ -74,7 +78,7 @@ An instance runner job executes an action on an instance.  Currently supported a
 
 ## Create a Job
 
-POST `/v1/minion/{account}/jobs`
+POST `/v1/minion/{account}/jobs/space-xy`
 
 ### Request
 
@@ -112,7 +116,7 @@ POST `/v1/minion/{account}/jobs`
 
 ## Update a Job
 
-PUT `/v1/minion/{account}/jobs/{id}`
+PUT `/v1/minion/{account}/jobs/space-xy/6bcfa79f-615e-470d-97c1-687f3357497d`
 
 ### Request
 
@@ -149,7 +153,7 @@ PUT `/v1/minion/{account}/jobs/{id}`
 }
 ```
 
-## List Jobs
+## List Jobs in an account
 
 GET `/v1/minion/{account}/jobs`
 
@@ -157,16 +161,29 @@ GET `/v1/minion/{account}/jobs`
 
 ```json
 [
+    "space-xy/11e7b876-7a10-4c3e-93a7-e77eb3c68b58",
+    "space-xy/6bcfa79f-615e-470d-97c1-687f3357497d",
+    "space-ab/747f437a-a4af-48b2-a021-888bb8943a9b",
+    "space-ab/7cf7433f-f6c2-496e-8fe9-ed4776d130c1"
+]
+```
+
+## List Jobs in a space
+
+GET `/v1/minion/{account}/jobs/space-xy`
+
+### Response
+
+```json
+[
     "11e7b876-7a10-4c3e-93a7-e77eb3c68b58",
-    "6bcfa79f-615e-470d-97c1-687f3357497d",
-    "747f437a-a4af-48b2-a021-888bb8943a9b",
-    "7cf7433f-f6c2-496e-8fe9-ed4776d130c1"
+    "6bcfa79f-615e-470d-97c1-687f3357497d"
 ]
 ```
 
 ## Get a Job
 
-GET `/v1/minion/{account}/jobs/{id}`
+GET `/v1/minion/{account}/jobs/space-xy/6bcfa79f-615e-470d-97c1-687f3357497d`
 
 ```json
 {
@@ -186,7 +203,20 @@ GET `/v1/minion/{account}/jobs/{id}`
 
 ## Delete a Job
 
-DELETE `/v1/minion/{account}/jobs/{id}`
+DELETE `/v1/minion/{account}/jobs/space-xy/6bcfa79f-615e-470d-97c1-687f3357497d`
+
+## Delete all jobs in a group
+
+DELETE `/v1/minion/{account}/jobs/space-xy`
+
+## Run a Job
+
+PATCH `/v1/minion/{account}/jobs/space-xy/6bcfa79f-615e-470d-97c1-687f3357497d`
+
+Note: At the moment, this checks if the job exists in the jobs repository and then adds it to the
+jobs queue.  There is a potential race condition, since the jobs queue reads from the local cache
+when executing jobs, so it may be missing if it was just created and hasn't been cached by the
+loader yet.
 
 ## Author
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -13,11 +13,16 @@ func (s *server) routes() {
 	api.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
 
 	api.HandleFunc("/{account}/jobs", s.JobsListHandler).Methods(http.MethodGet)
-	api.HandleFunc("/{account}/jobs", s.JobsCreateHandler).Methods(http.MethodPost)
-	api.HandleFunc("/{account}/jobs/{id}", s.JobsShowHandler).Methods(http.MethodGet)
-	api.HandleFunc("/{account}/jobs/{id}", s.JobsUpdateHandler).Methods(http.MethodPut)
-	api.HandleFunc("/{account}/jobs/{id}", s.JobsDeleteHandler).Methods(http.MethodDelete)
+
+	api.HandleFunc("/{account}/jobs/{group}", s.JobsListHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/jobs/{group}", s.JobsCreateHandler).Methods(http.MethodPost)
+
+	api.HandleFunc("/{account}/jobs/{group}/{id}", s.JobsShowHandler).Methods(http.MethodGet)
+	api.HandleFunc("/{account}/jobs/{group}/{id}", s.JobsUpdateHandler).Methods(http.MethodPut)
+
+	api.HandleFunc("/{account}/jobs/{group}", s.JobsDeleteHandler).Methods(http.MethodDelete)
+	api.HandleFunc("/{account}/jobs/{group}/{id}", s.JobsDeleteHandler).Methods(http.MethodDelete)
 
 	// TODO: remove this route one the jobs are running on a schedule
-	api.HandleFunc("/{account}/jobs/{id}", s.JobsRunHandler).Methods(http.MethodPatch)
+	api.HandleFunc("/{account}/jobs/{group}/{id}", s.JobsRunHandler).Methods(http.MethodPatch)
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -23,6 +23,5 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/jobs/{group}", s.JobsDeleteHandler).Methods(http.MethodDelete)
 	api.HandleFunc("/{account}/jobs/{group}/{id}", s.JobsDeleteHandler).Methods(http.MethodDelete)
 
-	// TODO: remove this route one the jobs are running on a schedule
 	api.HandleFunc("/{account}/jobs/{group}/{id}", s.JobsRunHandler).Methods(http.MethodPatch)
 }

--- a/jobs/jobsrepository.go
+++ b/jobs/jobsrepository.go
@@ -3,9 +3,9 @@ package jobs
 import "context"
 
 type Repository interface {
-	Create(ctx context.Context, account string, job *Job) (*Job, error)
-	Delete(ctx context.Context, account, id string) error
-	Get(ctx context.Context, account, id string) (*Job, error)
-	List(ctx context.Context, account string) ([]string, error)
-	Update(ctx context.Context, account, id string, job *Job) (*Job, error)
+	Create(ctx context.Context, account, group string, job *Job) (*Job, error)
+	Delete(ctx context.Context, account, group, id string) error
+	Get(ctx context.Context, account, group, id string) (*Job, error)
+	List(ctx context.Context, account, group string) ([]string, error)
+	Update(ctx context.Context, account, group, id string, job *Job) (*Job, error)
 }


### PR DESCRIPTION
This adds the concept of a `group` to our jobs management and storage.  This allows a caller to list all jobs, or just jobs within a group.  It also moves most job interactions under the group in the route.  The s3 implementation of the jobs repository uses the group as part of the prefix, however it could also be used as part of a db select or other mechanism for filtering on jobs.