### PR TITLE
Upgrade deco, remove aws cli

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,14 +27,10 @@ WORKDIR /app
 COPY --from=build-env /app/api.out /app/api
 RUN chmod 555 /app/api
 
-RUN apk add --no-cache bash ca-certificates wget python gettext && \
-    wget -nv "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" && \
-    unzip awscli-bundle.zip && \
-    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-    /usr/local/bin/aws --version
+RUN apk add --no-cache bash ca-certificates
 
 # Install Deco
-ARG DECO_VERSION=0.3.1
+ARG DECO_VERSION=0.4.1
 ARG DECO_OS=linux
 ARG DECO_ARCH=amd64
 ADD https://github.com/YaleUniversity/deco/releases/download/v${DECO_VERSION}/deco-v${DECO_VERSION}-${DECO_OS}-${DECO_ARCH} /usr/local/bin/deco

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN chmod 555 /app/api
 RUN apk add --no-cache bash ca-certificates
 
 # Install Deco
-ARG DECO_VERSION=0.4.1
+ARG DECO_VERSION=0.5.0
 ARG DECO_OS=linux
 ARG DECO_ARCH=amd64
 ADD https://github.com/YaleUniversity/deco/releases/download/v${DECO_VERSION}/deco-v${DECO_VERSION}-${DECO_OS}-${DECO_ARCH} /usr/local/bin/deco

--- a/docker/import_config.sh
+++ b/docker/import_config.sh
@@ -5,9 +5,9 @@
 
 if [ -n "$SSMPATH" ]; then
   echo "Getting config file from SSM Parameter Store (${SSMPATH}) ..."
-  aws --version
+  deco version
   if [[ $? -ne 0 ]]; then
-    echo "ERROR: aws-cli not found!"
+    echo "ERROR: deco not found!"
     exit 1
   fi
   deco validate ssm://${SSMPATH} || exit 1

--- a/docker/import_config.sh
+++ b/docker/import_config.sh
@@ -10,8 +10,8 @@ if [ -n "$SSMPATH" ]; then
     echo "ERROR: deco not found!"
     exit 1
   fi
-  deco validate ssm://${SSMPATH} || exit 1
-  deco run ssm://${SSMPATH}
+  deco validate -e ssm://${SSMPATH} || exit 1
+  deco run -e ssm://${SSMPATH}
 else
   echo "ERROR: SSMPATH variable not set!"
   exit 1

--- a/docker/import_config.sh
+++ b/docker/import_config.sh
@@ -10,10 +10,8 @@ if [ -n "$SSMPATH" ]; then
     echo "ERROR: aws-cli not found!"
     exit 1
   fi
-  aws --region us-east-1 ssm get-parameter --name "${SSMPATH}" --with-decryption --output text --query Parameter.Value | base64 -d > deco-config.json
-  deco validate deco-config.json || exit 1
-  deco run deco-config.json
-  rm -f deco-config.json config.encrypted
+  deco validate ssm://${SSMPATH} || exit 1
+  deco run ssm://${SSMPATH}
 else
   echo "ERROR: SSMPATH variable not set!"
   exit 1


### PR DESCRIPTION
This requires adding another environment variable to the task definition - AWS_REGION.  We could also default it in deco but I imagine we might want it at some point at the API level.