### PR TITLE
Return next run with job endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ POST `/v1/minion/{account}/jobs/space-xy`
             "key": "baz",
             "value": "biz"
         }
-    ]
+    ],
+    "next": "2020-02-27T16:23:09Z"
 }
 ```
 
@@ -222,7 +223,8 @@ PUT `/v1/minion/{account}/jobs/space-xy/6bcfa79f-615e-470d-97c1-687f3357497d`
             "key": "baz",
             "value": "biz"
         }
-    ]
+    ],
+    "next": "2020-02-27T16:23:09Z"
 }
 ```
 
@@ -282,7 +284,8 @@ GET `/v1/minion/{account}/jobs/space-xy/6bcfa79f-615e-470d-97c1-687f3357497d`
             "key": "baz",
             "value": "biz"
         }
-    ]
+    ],
+    "next": "2020-02-27T16:23:09Z"
 }
 ```
 

--- a/jobs/instancerunner_test.go
+++ b/jobs/instancerunner_test.go
@@ -212,6 +212,9 @@ func TestInstanceRunnerRun(t *testing.T) {
 		"token":            "my-awesome-token",
 		"endpointTemplate": fmt.Sprintf("%s/{{.Account}}/{{.InstanceID}}", ts.URL),
 	})
+	if err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
 
 	out, err = instanceRunnerTmpl.Run(context.TODO(), "myaccount", map[string]string{
 		"instance_id":     "i-123456",
@@ -229,8 +232,11 @@ func TestInstanceRunnerRun(t *testing.T) {
 		"token":            "my-awesome-token",
 		"endpointTemplate": fmt.Sprintf("%s/some-bad-url", ts.URL),
 	})
+	if err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
 
-	out, err = instanceRunnerBadURL.Run(context.TODO(), "myaccount", map[string]string{
+	_, err = instanceRunnerBadURL.Run(context.TODO(), "myaccount", map[string]string{
 		"instance_id":     "i-123456",
 		"instance_action": "stop",
 	})

--- a/jobs/job.go
+++ b/jobs/job.go
@@ -39,7 +39,7 @@ func NewID() string {
 	return id
 }
 
-// UnmarshalJSON is a custom JSON unmarshaller for metadata
+// UnmarshalJSON is a custom JSON unmarshaller for a job
 func (m *Job) UnmarshalJSON(j []byte) error {
 	var rawStrings map[string]interface{}
 
@@ -203,4 +203,18 @@ func (m *Job) MarshalBinary() ([]byte, error) {
 
 func (m *Job) UnmarshalBinary(data []byte) error {
 	return m.UnmarshalJSON(data)
+}
+
+// NextRun returns the next invocation of the schedule expression
+func (j *Job) NextRun(t time.Time) (*time.Time, error) {
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+
+	c, err := parser.Parse(j.ScheduleExpression)
+	if err != nil {
+		return nil, err
+	}
+
+	next := c.Next(t)
+
+	return &next, nil
 }


### PR DESCRIPTION
This returns the simple case next run -- ie. it doesn't check if the job is loaded into the scheduler yet.  we can do that in the future once the jobcache lives somewhere outside of the API process.